### PR TITLE
Re-enable magit-svn extension

### DIFF
--- a/layers/+source-control/git/packages.el
+++ b/layers/+source-control/git/packages.el
@@ -22,8 +22,7 @@
         (helm-gitignore :toggle (configuration-layer/package-usedp 'helm))
         magit
         magit-gitflow
-        ;; not compatible with magit 2.1 at the time of release
-        ;; magit-svn
+        magit-svn
         orgit
         smeargle
         ))


### PR DESCRIPTION
Magit-svn extension has been compatible with magit 2.1 for a long time, so re-enable it and remove outdated comment.
